### PR TITLE
Update Gemfiles for new spree gem location

### DIFF
--- a/page_builder/Gemfile
+++ b/page_builder/Gemfile
@@ -13,7 +13,7 @@ platforms :ruby do
   gem 'sqlite3', '>= 2.0'
 end
 
-spree_opts = { github: 'spree/spree', branch: 'main' }
+spree_opts = { github: 'spree/spree', branch: 'main', glob: 'backend/engines/**/*.gemspec' }
 gem 'spree', spree_opts
 gem 'spree_admin', spree_opts
 

--- a/storefront/Gemfile
+++ b/storefront/Gemfile
@@ -13,7 +13,7 @@ platforms :ruby do
   gem 'sqlite3', '>= 2.0'
 end
 
-spree_opts = { github: 'spree/spree', branch: 'main' }
+spree_opts = { github: 'spree/spree', branch: 'main', glob: 'backend/engines/**/*.gemspec' }
 gem 'spree', spree_opts
 gem 'spree_admin', spree_opts
 gem 'spree_page_builder', path: '../page_builder'


### PR DESCRIPTION
## Summary
- Updates the Bundler github source for spree/spree to include `glob: 'backend/engines/**/*.gemspec'` in both `storefront/Gemfile` and `page_builder/Gemfile`
- The spree gems have been moved from the root of the spree/spree repository to `backend/engines/`

## Test plan
- [x] `bundle update` succeeds (both storefront and page_builder)
- [x] `bundle exec rake test_app` succeeds
- [x] `bundle exec rspec` passes for storefront (429 non-feature examples, 0 failures; feature spec failures are pre-existing Selenium issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)