### PR TITLE
Ability to hide system sections

### DIFF
--- a/page_builder/app/models/spree/page_section.rb
+++ b/page_builder/app/models/spree/page_section.rb
@@ -122,6 +122,10 @@ module Spree
       role == 'content'
     end
 
+    def can_be_hidden?
+      false
+    end
+
     def can_be_sorted?
       true
     end

--- a/page_builder/app/models/spree/page_sections/announcement_bar.rb
+++ b/page_builder/app/models/spree/page_sections/announcement_bar.rb
@@ -8,8 +8,14 @@ module Spree
       BOTTOM_PADDING_DEFAULT = 8
       TOP_BORDER_WIDTH_DEFAULT = 0
 
+      preference :visible, :boolean, default: true
+
       def self.role
         'header'
+      end
+
+      def can_be_hidden?
+        true
       end
 
       def icon_name

--- a/page_builder/app/views/spree/admin/page_builder/_sidebar_section.html.erb
+++ b/page_builder/app/views/spree/admin/page_builder/_sidebar_section.html.erb
@@ -1,19 +1,21 @@
 <% if section.persisted? %>
+  <% section_hidden = section.can_be_hidden? && !section.preferred_visible %>
   <%= turbo_frame_tag dom_id(section), class: 'list-group-item py-0 border-0 sidebar-page-section draggable rounded-sm',
                                        data: { sortable_update_url: spree.admin_page_section_path(section, format: :turbo_stream) } do %>
-    <div class="flex items-center justify-between sidebar-section-title py-1 rounded-xl"
+    <div class="flex items-center justify-between sidebar-section-title py-1 rounded-xl <%= 'opacity-50' if section_hidden %>"
          data-action="mouseover->page-builder#toggleHighlightElement mouseout->page-builder#toggleHighlightElement"
       data-page-builder-editor-id-param="section-<%= section.id %>">
       <div class="flex items-center flex-1 py-1 px-2">
         <%= icon("#{section.icon_name}", height: 18, class: 'mr-2') if section.icon_name.present? %>
         <%= link_to section.display_name, spree.edit_admin_page_section_path(section),
-            class: 'section-edit-link flex-1 font-bold text-gray-900',
+            class: "section-edit-link flex-1 font-bold #{section_hidden ? 'text-gray-400' : 'text-gray-900'}",
             data: {
               turbo_frame: :page_sidebar,
               action: 'click->page-builder#makeOverlayActive',
               page_builder_editor_id_param: "section-#{section.id}"
             }
         %>
+        <%= icon('eye-off', height: 14, class: 'ml-1 text-gray-400') if section_hidden %>
       </div>
       <div class="flex items-center hidden">
         <button class="btn btn-sm pr-0 handle hover:bg-gray-100 h-full mr-1 px-1 handle-section shadow-none">

--- a/page_builder/app/views/spree/admin/page_sections/edit.html.erb
+++ b/page_builder/app/views/spree/admin/page_sections/edit.html.erb
@@ -18,6 +18,12 @@
           </li>
         </ul>
         <div data-tabs-target="panel" id="pills-home" role="tabpanel" aria-labelledby="pills-home-tab" class="animate-fade-in" <%= 'hidden' unless tab_selected == :content %>>
+          <% if @page_section.can_be_hidden? %>
+            <div class="form-group">
+              <%= f.check_box :preferred_visible, class: "checkbox-input", data: { action: 'auto-submit#submit' } %>
+              <%= f.label :preferred_visible, Spree.t('admin.page_builder.visible') %>
+            </div>
+          <% end %>
           <%= render "spree/admin/page_sections/forms/#{@page_section.type.demodulize.underscore}", f: f  %>
           <%= render 'spree/admin/page_sections/form_tab_buttons', tab: :content %>
         </div>

--- a/page_builder/app/views/spree/admin/page_sections/update.turbo_stream.erb
+++ b/page_builder/app/views/spree/admin/page_sections/update.turbo_stream.erb
@@ -8,3 +8,8 @@
     <%= render 'spree/admin/page_links/linkable_type_dropdown', page_link: @page_section.link, form_name: 'page_section[link_attributes]' %>
   <% end %>
 <% end %>
+<% if @page_section.can_be_hidden? && @page_section.previous_changes.key?('preferences') %>
+  <%= turbo_stream.replace dom_id(@page_section) do %>
+    <%= render 'spree/admin/page_builder/sidebar_section', section: @page_section %>
+  <% end %>
+<% end %>

--- a/page_builder/app/views/spree/admin/page_sections/update.turbo_stream.erb
+++ b/page_builder/app/views/spree/admin/page_sections/update.turbo_stream.erb
@@ -8,7 +8,8 @@
     <%= render 'spree/admin/page_links/linkable_type_dropdown', page_link: @page_section.link, form_name: 'page_section[link_attributes]' %>
   <% end %>
 <% end %>
-<% if @page_section.can_be_hidden? && @page_section.previous_changes.key?('preferences') %>
+<% if @page_section.can_be_hidden? && @page_section.saved_change_to_preferences? &&
+      @page_section.saved_change_to_preferences[0][:visible] != @page_section.saved_change_to_preferences[1][:visible] %>
   <%= turbo_stream.replace dom_id(@page_section) do %>
     <%= render 'spree/admin/page_builder/sidebar_section', section: @page_section %>
   <% end %>

--- a/page_builder/config/locales/en.yml
+++ b/page_builder/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         title: Title
         top_padding: Top padding
         use_description_from_admin: Use description from admin
+        visible: Visible
         vertical_alignment: Vertical alignment
         youtube_video_url: Youtube video URL
     default_theme_name: Default Theme

--- a/page_builder/spec/jobs/spree/themes/duplicate_components_job_spec.rb
+++ b/page_builder/spec/jobs/spree/themes/duplicate_components_job_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Spree::Themes::DuplicateComponentsJob do
         top_padding: 20,
         bottom_padding: 20,
         top_border_width: 2,
-        bottom_border_width: 4
+        bottom_border_width: 4,
+        visible: true
       }
     )
   end

--- a/storefront/app/helpers/spree/page_helper.rb
+++ b/storefront/app/helpers/spree/page_helper.rb
@@ -28,6 +28,9 @@ module Spree
     def render_section(section, variables = {}, lazy_allowed: true)
       return '' if section.blank?
 
+      hidden = section.can_be_hidden? && !section.preferred_visible
+      return '' if hidden && !page_builder_enabled?
+
       variables[:section] = section
       variables[:loaded] = true
 
@@ -41,7 +44,8 @@ module Spree
               editor_id: css_id,
               editor_name: section.name,
               editor_link: spree.edit_admin_page_section_path(section)
-            }
+            },
+            style: (hidden ? 'opacity: 0.4;' : nil)
           ) do
             render('/' + section.to_partial_path, **variables)
           end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page sections can be hidden/shown via a visibility toggle in the editor.
  * Hidden sections show visual indicators: dimmed in the storefront and an eye-off icon + muted header in the admin sidebar.
  * Announcement bars are the first section type to support hiding.

* **Documentation**
  * Added admin translation for the visibility label.

* **Tests**
  * Updated duplication test fixtures to include the visibility preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->