### PR TITLE
Prepare release for Spree 5.4

### DIFF
--- a/lib/spree_storefront/version.rb
+++ b/lib/spree_storefront/version.rb
@@ -1,3 +1,3 @@
 module SpreeStorefront
-  VERSION = '5.4.0.alpha'.freeze
+  VERSION = '5.4.0'.freeze
 end

--- a/page_builder/spree_page_builder.gemspec
+++ b/page_builder/spree_page_builder.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.files        = Dir["{app,config,db,lib,vendor}/**/*", "LICENSE.md", "Rakefile", "README.md"].reject { |f| f.match(/^spec/) && !f.match(/^spec\/fixtures/) }
   s.require_path = 'lib'
 
-  spree_version = ">= 5.4.0.rc4"
+  spree_version = ">= 5.4.0"
   s.add_dependency 'spree', spree_version
   s.add_dependency 'spree_admin', spree_version
   s.add_dependency 'spree_posts'

--- a/storefront/app/finders/spree/storefront/variant_finder.rb
+++ b/storefront/app/finders/spree/storefront/variant_finder.rb
@@ -48,7 +48,7 @@ module Spree
             variant = @product.variants.find(variant_id)
             @variant_from_options = variant
             @selected_variant = variant
-          elsif product_option_types.size == 1 && product_option_types.first.color?
+          elsif product_option_types.size == 1 && product_option_types.first.color_swatch?
             @selected_variant = @variant_from_options = @product.variants.find { |v| v.purchasable? && v.price_in(current_currency).amount.present? }
           elsif @product.variants.size == 1 || product_has_only_one_secondary_option_type_value?
             @variant_from_options = @product.variants.first
@@ -64,7 +64,7 @@ module Spree
 
       def product_has_only_one_secondary_option_type_value?
         return false unless product_option_types.size == 2
-        return false unless product_option_types.first.color?
+        return false unless product_option_types.first.color_swatch?
 
         @product.
           option_values.

--- a/storefront/app/helpers/spree/cart_helper.rb
+++ b/storefront/app/helpers/spree/cart_helper.rb
@@ -31,7 +31,7 @@ module Spree
       @color_options_style_for_line_items = begin
         colors = line_items.map(&:variant).map do |v|
           color_option_values = v.option_values.includes(:option_type).find_all do |ov|
-            ov.option_type.color?
+            ov.option_type.color_swatch?
           end
 
           color_option_values.map do |ov|

--- a/storefront/app/helpers/spree/products_helper.rb
+++ b/storefront/app/helpers/spree/products_helper.rb
@@ -112,7 +112,7 @@ module Spree
       end
 
       images << product.master&.images&.to_a
-      images << product.default_image if images.flatten.compact.empty?
+      images << product.primary_media if images.flatten.compact.empty?
 
       images.flatten.compact.uniq(&:id)
     end

--- a/storefront/app/helpers/spree/products_helper.rb
+++ b/storefront/app/helpers/spree/products_helper.rb
@@ -82,9 +82,9 @@ module Spree
           selected_variant.option_values.find { |ov| ov.option_type_id == option_type.id }
         elsif product_selected_options_hash.present? && product_selected_options_hash[option_type.id.to_s].present? # user selected variant which is not available
           option_type.option_values.find { |v| v.name == product_selected_options_hash[option_type.id.to_s] }
-        elsif option_type.color? && (available_variant = product.first_available_variant(current_currency))
+        elsif option_type.color_swatch? && (available_variant = product.first_available_variant(current_currency))
           available_variant.option_values.find { |ov| ov.option_type_id == option_type.id }
-        elsif option_type.color? && product.first_available_variant(current_currency).nil?
+        elsif option_type.color_swatch? && product.first_available_variant(current_currency).nil?
           product.variants.first&.option_values&.find { |ov| ov.option_type_id == option_type.id }
         end
     end
@@ -226,7 +226,7 @@ module Spree
     end
 
     def option_type_colors_preview_styles(option_type)
-      return unless option_type.color?
+      return unless option_type.color_swatch?
 
       Spree::ColorsPreviewStylesPresenter.new(option_type.option_values.map { |ov| { name: ov.name, filter_name: ov.name } }).to_s
     end

--- a/storefront/app/helpers/spree/storefront_helper.rb
+++ b/storefront/app/helpers/spree/storefront_helper.rb
@@ -60,7 +60,7 @@ module Spree
       return @page_image if @page_image.present?
 
       if object.is_a? Spree::Product
-        @page_image = object.default_image&.attachment
+        @page_image = object.primary_media&.attachment
       elsif object.respond_to?(:image)
         @page_image = object.image
       end

--- a/storefront/app/views/spree/checkout/_line_item.html.erb
+++ b/storefront/app/views/spree/checkout/_line_item.html.erb
@@ -3,7 +3,7 @@
     <span class="rounded-full text-xs text-center font-bold pl-[0.5px] py-1 w-6 text-sidebar-text bg-background absolute -right-2 -top-3">
       <%= line_item.quantity %>
     </span>
-    <% image = line_item.variant.default_image %>
+    <% image = line_item.variant.primary_media %>
     <% if image.present? && image.attached? && image.variable? %>
       <%= spree_image_tag(image, class: 'rounded-sm border border-default bg-transparent object-cover object-center', loading: :lazy, variant: :mini, width: 64, height: 64) %>
     <% else %>

--- a/storefront/app/views/themes/default/spree/orders/_line_item.html.erb
+++ b/storefront/app/views/themes/default/spree/orders/_line_item.html.erb
@@ -2,7 +2,7 @@
   <li class="cart-line-item flex items-top py-6 px-4 w-full">
     <div class="line-item-overlay"></div>
       <div class="cart-product-image shrink-0" id="<%= dom_id(line_item) %>-image" data-turbo-permanent>
-        <% image = line_item.variant.default_image %>
+        <% image = line_item.variant.primary_media %>
         <% if image.present? && image.attached? && image.variable? %>
           <%= link_to spree_storefront_resource_url(line_item.product), data: { 'turbo-frame': '_top' } do %>
             <%= spree_image_tag(image, width: 128, height: 128, variant: :small, class: 'object-cover', loading: :lazy) %>

--- a/storefront/app/views/themes/default/spree/products/_color_swatches.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_color_swatches.html.erb
@@ -1,4 +1,4 @@
-<% color_option = product.option_types.find { |option_type| option_type.color? } %>
+<% color_option = product.option_types.find { |option_type| option_type.color_swatch? } %>
 <% variants_with_color = product.variants.find_all { |variant| variant.option_values.find { |ov| ov.option_type_id == color_option.id } } if color_option.present? %>
 
 <% if color_option.present? && variants_with_color.length > 0 %>

--- a/storefront/app/views/themes/default/spree/products/_color_swatches.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_color_swatches.html.erb
@@ -31,7 +31,7 @@
                 color_preview_container_class: "lg:w-[28px] lg:h-[28px]",
                 color_preview_class: "lg:top-[2px] lg:left-[2px]" %>
             <% end %>
-            <% if selected_variant.has_images? || selected_variant.default_image.present? %>
+            <% if selected_variant.has_images? || selected_variant.primary_media.present? %>
               <template data-featured-image-template>
                 <%= render 'spree/products/featured_image',
                   object: selected_variant %>

--- a/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
@@ -1,7 +1,7 @@
 <% with_cover_image ||= true %>
 <% object ||= product %>
 
-<% if object.default_image.present? && object.default_image.attached? %>
+<% if object.primary_media.present? && object.primary_media.attached? %>
   <% height ||= theme_setting('product_listing_image_height') %>
   <% width ||= theme_setting('product_listing_image_width') %>
   <figure class="group <%= 'aspect-1' if height == width %> card-product-featured-images-container bg-transparent h-full">
@@ -13,7 +13,7 @@
     <% image_hover_class = object.secondary_image.present? && object.secondary_image.attached? ? 
          "w-full group-hover:opacity-0 transition-opacity duration-500 z-10 relative h-full bg-background product-card !max-h-full #{object_class}" :
          "w-full h-full !max-h-full #{object_class}" %>
-    <%= spree_image_tag(object.default_image, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.primary_image', default: 'primary image')}", class: image_hover_class) %>
+    <%= spree_image_tag(object.primary_media, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.primary_image', default: 'primary image')}", class: image_hover_class) %>
     <% if object.has_images? && object.image_count > 1 && object.secondary_image.present? && object.secondary_image.attached? %>
       <% secondary_image_class = "w-full absolute top-0 left-0 opacity-100 h-full !max-h-full #{object_class}" %>
       <%= spree_image_tag(object.secondary_image, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.secondary_image', default: 'secondary image')}", class: secondary_image_class) %>

--- a/storefront/app/views/themes/default/spree/products/_filters.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_filters.html.erb
@@ -24,7 +24,7 @@
         <% end %>
 
         <% Spree::OptionType.filterable.order(:position).includes(:option_values).each do |filter| %>
-          <% if filter.color? %>
+          <% if filter.color_swatch? %>
             <%= render 'spree/products/filters/colors', filter: filter, f: f %>
           <% else %>
             <%= render 'spree/products/filters/generic', filter: filter, f: f %>

--- a/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_json_ld.html.erb
@@ -7,7 +7,7 @@
     "url": <%= spree.product_url(product, host: current_store.url_or_custom_domain).to_json.html_safe %>,
   <% if product.has_images? %>
     "image": [
-      <%= spree_image_url(product.default_image, variant: :large).to_json.html_safe %>
+      <%= spree_image_url(product.primary_media, variant: :large).to_json.html_safe %>
     ],
   <% end %>
   <% if product.description.present? %>

--- a/storefront/app/views/themes/default/spree/products/_variant_options.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_variant_options.html.erb
@@ -31,7 +31,7 @@
       <% end %>
     <% end %>
   <% end %>
-  <% if option_type.color? %>
+  <% if option_type.color_swatch? %>
     <li role="option" aria-label="<%= value.presentation %>">
       <label class="cursor-pointer"  aria-label="<%= value.presentation %>">
         <%= radio_button_tag option_type.presentation, value.name, selected_option == value,

--- a/storefront/app/views/themes/default/spree/products/_variant_picker.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_variant_picker.html.erb
@@ -3,7 +3,7 @@
   <div id='product-variant-picker' class="flex flex-col gap-y-4 mb-4 mt-2">
     <% product.option_types.each_with_index do |option_type, index| %>
       <% selected_option = product_selected_option_for_option(option_type, product: product, selected_variant: selected_variant, options_param_name: options_param_name) %>
-      <% if option_type.color? %>
+      <% if option_type.color_swatch? %>
         <%= option_type_colors_preview_styles(option_type).html_safe %>
         <fieldset data-option-id="<%= option_type.id %>" class="flex flex-col gap-y-2">
           <span class="text-sm leading-4 uppercase tracking-widest"><%= option_type.presentation %>: <%= selected_option.presentation %></span>

--- a/storefront/app/views/themes/default/spree/shared/_line_item_options.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_line_item_options.html.erb
@@ -1,6 +1,6 @@
 <% options = line_item.variant.option_values %>
 
-<% options.select { |ov| ov.option_type.color? }.each do |option| %>
+<% options.select { |ov| ov.option_type.color_swatch? }.each do |option| %>
   <div>
     <input class="hidden color-input" value="<%= option.name %>" >
     <div class="label-container h-[30px] border border-default p-0.5 inline-flex items-center hover:border-dashed hover:border-primary">
@@ -11,7 +11,7 @@
     </div>
   </div>
 <% end %>
-<% options.reject { |ov| ov.option_type.color? }.each do |option| %>
+<% options.reject { |ov| ov.option_type.color_swatch? }.each do |option| %>
   <div>
     <div class="h-[30px] border border-default px-2 inline-flex items-center hover:border-dashed hover:border-primary text-sm">
       <%= option.presentation %>

--- a/storefront/app/views/themes/default/spree/shared/_order_line_item.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_order_line_item.html.erb
@@ -3,7 +3,7 @@
 <div class="flex flex-col gap-4">
   <div class="flex gap-4">
     <div class="shrink-0">
-      <% image = line_item.variant.default_image %>
+      <% image = line_item.variant.primary_media %>
       <% if image.present? && image.attached? && image.variable? %>
         <%= link_to spree_storefront_resource_url(line_item.product, relative: true) do %>
           <%= spree_image_tag(image, width: 128, height: 128, variant: :small, loading: :lazy) %>

--- a/storefront/spec/features/product_details_page_spec.rb
+++ b/storefront/spec/features/product_details_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Product detail page', type: :feature do
 
   let!(:product) { create(:product_in_stock, taxons: [shoes, brand], description: 'Product description', price: 100.0, stores: [store]) }
 
-  let!(:color) { create(:option_type, name: 'color', presentation: 'Color') }
+  let!(:color) { create(:option_type, name: 'color', presentation: 'Color', kind: 'color_swatch') }
   let!(:black) { create(:option_value, option_type: color, name: 'black', presentation: 'Black') }
   let!(:red) { create(:option_value, option_type: color, name: 'red', presentation: 'Red') }
   let!(:white) { create(:option_value, option_type: color, name: 'white', presentation: 'White') }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Stable production release v5.4.0 now available
* **Chores**
  * Updated Spree and Spree Admin dependency requirements to v5.4.0 or later
* **Product Media**
  * Product images/media unified across checkout, orders, product pages, and structured data to use primary media where available
* **Product Options / UI**
  * Color options now use color-swatch behavior across filters, swatches, variant pickers, and cart displays
* **Tests**
  * Specs updated to reflect color-swatch option type configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->