### PR TITLE
Fix: page_builder should work without spree_multi_store

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,19 @@ concurrency:
 
 jobs:
   test_page_builder:
-    name: Page Builder (${{ matrix.db }})
+    name: Page Builder (${{ matrix.db }}${{ matrix.disable_spree_multi_store == 'true' && ', no spree_multi_store' || '' }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        db: [postgres, mysql]
         include:
           - db: postgres
             database_url: postgres://postgres:password@localhost:5432/spree_test
           - db: mysql
             database_url: mysql2://root:password@127.0.0.1:3306/spree_test
+          - db: postgres
+            database_url: postgres://postgres:password@localhost:5432/spree_test
+            disable_spree_multi_store: 'true'
     services:
       postgres:
         image: postgres:16
@@ -49,6 +51,7 @@ jobs:
     env:
       DB: ${{ matrix.db }}
       DATABASE_URL: ${{ matrix.database_url }}
+      DISABLE_SPREE_MULTI_STORE: ${{ matrix.disable_spree_multi_store }}
       RAILS_ENV: test
       CI: true
     steps:

--- a/page_builder/Gemfile
+++ b/page_builder/Gemfile
@@ -21,7 +21,7 @@ spree_opts = if ENV['SPREE_PATH']
 gem 'spree', spree_opts
 gem 'spree_admin', spree_opts
 
-gem 'spree_multi_store', github: 'spree/spree-multi-store', branch: 'main'
+gem 'spree_multi_store', github: 'spree/spree-multi-store', branch: 'main' unless ENV['DISABLE_SPREE_MULTI_STORE'] == 'true'
 gem 'spree_posts', github: 'spree/spree-posts', branch: 'main'
 gem 'spree_dev_tools', '>= 0.6.0.rc1'
 

--- a/page_builder/app/views/spree/admin/dashboard/_store_preview.html.erb
+++ b/page_builder/app/views/spree/admin/dashboard/_store_preview.html.erb
@@ -29,7 +29,7 @@
         <% end %>
       </div>
     </div>
-    <% unless current_store.default_custom_domain&.active? %>
+    <% if current_store.respond_to?(:default_custom_domain) && !current_store.default_custom_domain&.active? %>
       <div class="card-footer border-t p-2">
         <%= link_to_with_icon 'world-www', 'Connect your own domain', spree.admin_custom_domains_path, class: 'btn btn-secondary w-full py-2' %>
       </div>

--- a/page_builder/app/views/spree/admin/themes/index.html.erb
+++ b/page_builder/app/views/spree/admin/themes/index.html.erb
@@ -15,7 +15,7 @@
   </div>
   <br />
 
-  <% unless current_store.default_custom_domain&.active? %>
+  <% if current_store.respond_to?(:default_custom_domain) && !current_store.default_custom_domain&.active? %>
     <div class="alert alert-info inline-flex items-center py-2 pr-2">
       <div class="flex items-center">
         <span>


### PR DESCRIPTION
## Summary

- Guard `current_store.default_custom_domain` calls in `themes/index.html.erb` and `dashboard/_store_preview.html.erb` with `respond_to?`, since the association only exists when `spree_multi_store` is installed
- Make `spree_multi_store` conditional in `page_builder/Gemfile` via `DISABLE_SPREE_MULTI_STORE=true`
- Add a CI matrix entry that runs page_builder specs without `spree_multi_store` to catch regressions

### Why

The two admin views called `current_store.default_custom_domain&.active?` unconditionally. `default_custom_domain` is a `has_one` association defined only in `Spree::Store::MultiStoreMethods` (from the `spree_multi_store` extension), so stores without that extension installed would crash with `NoMethodError` when rendering the themes index or admin dashboard. CI previously masked this because the gem was listed unconditionally in `page_builder/Gemfile`.

`url_or_custom_domain` and `formatted_url_or_custom_domain` live in `spree_core` and don't need guarding.

## Test plan

- [x] `bundle exec rspec` on `page_builder` with spree_multi_store → 130 examples, 0 failures
- [x] `DISABLE_SPREE_MULTI_STORE=true bundle exec rspec` on `page_builder` → 130 examples, 0 failures
- [x] Verified `Spree::Store.new.respond_to?(:default_custom_domain)` returns `false` when the extension isn't loaded, and `true` when it is
- [x] Verified `url_or_custom_domain` / `formatted_url_or_custom_domain` remain available from core in both configurations
- [ ] CI matrix job `Page Builder (postgres, no spree_multi_store)` runs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of admin dashboard pages by adding safety checks for multi-store feature availability, preventing errors when the feature is disabled.

* **Chores**
  * Extended continuous integration testing to cover configurations with multi-store feature disabled.
  * Made multi-store functionality optional and configurable through environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->