### PR TITLE
Fix XSS vulnerability in product description rendering

### DIFF
--- a/storefront/app/views/themes/default/spree/products/_description.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_description.html.erb
@@ -2,7 +2,7 @@
   <% description_text = strip_tags(product.storefront_description) %>
   <div data-controller="read-more" class="flex flex-col gap-4" data-read-more-more-text-value="<%= Spree.t(:read_more) %>" data-read-more-less-text-value="Read less">
     <div class="prose product-description text-sm <%= 'product-description-truncated' if description_text.size > 250 %>" data-read-more-target="content">
-      <%= raw(product.storefront_description) %>
+      <%= sanitize(product.storefront_description) %>
     </div>
     <% if description_text.size > 250 %>
       <%= button_tag Spree.t(:read_more), type: 'button', data: { action: "read-more#toggle" }, class: "font-bold underline text-sm" %>

--- a/storefront/app/views/themes/default/spree/products/_details.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_details.html.erb
@@ -3,7 +3,7 @@
     <% description_text = strip_tags(product.storefront_description) %>
     <div data-controller="read-more" class="py-4 flex flex-col gap-4" data-read-more-more-text-value="<%= Spree.t(:read_more) %>" data-read-more-less-text-value="Read less">
       <div class="prose product-description text-sm <%= 'product-description-truncated' if description_text.size > 250 %>" data-read-more-target="content">
-        <%= raw(product.storefront_description) %>
+        <%= sanitize(product.storefront_description) %>
       </div>
       <% if description_text.size > 250 %>
         <%= button_tag Spree.t(:read_more), type: 'button', data: { action: "read-more#toggle" }, class: "font-bold underline text-sm" %>


### PR DESCRIPTION
## Summary
- Replace `raw()` with `sanitize()` in product description templates to prevent stored XSS
- `raw()` disabled all HTML escaping, allowing malicious scripts (e.g. `<script>`, `<img onerror>`) injected via TinyMCE source view or direct API calls to execute on the storefront for all visitors
- `sanitize()` strips dangerous tags/attributes while preserving safe formatting HTML (bold, italic, lists, headings, links, images, tables) that TinyMCE produces

## Test plan
- [ ] Verify product descriptions with standard formatting (bold, italic, lists, links) still render correctly
- [ ] Verify `<script>alert(1)</script>` in a product description is stripped and does not execute
- [ ] Verify `<img src=x onerror="alert(1)">` in a product description is sanitized (onerror removed)
- [ ] Verify the "Read more" truncation still works on long descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)