### PR TITLE
Fixed bad image check

### DIFF
--- a/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
+++ b/storefront/app/views/themes/default/spree/products/_featured_image.html.erb
@@ -14,7 +14,7 @@
          "w-full group-hover:opacity-0 transition-opacity duration-500 z-10 relative h-full bg-background product-card !max-h-full #{object_class}" :
          "w-full h-full !max-h-full #{object_class}" %>
     <%= spree_image_tag(object.primary_media, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.primary_image', default: 'primary image')}", class: image_hover_class) %>
-    <% if object.has_images? && object.image_count > 1 && object.secondary_image.present? && object.secondary_image.attached? %>
+    <% if object.has_images? && object.secondary_image.present? && object.secondary_image.attached? %>
       <% secondary_image_class = "w-full absolute top-0 left-0 opacity-100 h-full !max-h-full #{object_class}" %>
       <%= spree_image_tag(object.secondary_image, width: width, height: height, variant: :medium, loading: :lazy, alt: "#{object.name} #{Spree.t('storefront.products.secondary_image', default: 'secondary image')}", class: secondary_image_class) %>
     <% end %>


### PR DESCRIPTION
`image_count` was renamed to `media_count` in Spree 5.4, however it's already redundant as `has_images?` already runs a proper check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined product image display logic to show secondary images in more scenarios based on image availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->