### PR TITLE
Fix respecting of explore more button preference from theme editor

### DIFF
--- a/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
+++ b/storefront/app/views/themes/default/spree/page_sections/_featured_taxon.html.erb
@@ -35,7 +35,7 @@
               </div>
             <% end %>
           </div>
-          <% if section.taxon.present? %>
+          <% if section.taxon.present? && section.preferred_show_more_button %>
             <%= link_to spree_storefront_resource_url(section.taxon), class: class_names(section.preferred_button_style == "primary" ? "btn-primary" : "btn-secondary", " text-center hidden md:inline-block"), data: { turbo_frame: '_top' } do %>
               <%= section.preferred_button_text %>
             <% end %>


### PR DESCRIPTION
The featured_taxon partial has the button preference in page_builder to not show the explore category button, but it's not being respected when the taxon is available. Simply adding the preference in as a guard clause resolves this in the default theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "show more" button logic in the featured taxon section to properly respect button visibility preferences along with taxon presence requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->