### PR TITLE
EC-1209 - Fix og_image variant crash when product has no images

### DIFF
--- a/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
@@ -22,7 +22,7 @@
 <meta property="og:description" content="<%= h(og_description) %>">
 
 <% if page_image.present? && page_image.attached? && page_image.variable? %>
-  <% if @product && !page_image.record.is_a?(Spree::Store) %>
+  <% if @product && page_image.record.is_a?(Spree::Asset) %>
     <% image_url = spree_image_url(page_image, variant: :og_image) %>
   <% else %>
     <% image_url = spree_image_url(page_image, width: 1200, height: 630) %>

--- a/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
+++ b/storefront/app/views/themes/default/spree/shared/_meta_tags.html.erb
@@ -22,7 +22,7 @@
 <meta property="og:description" content="<%= h(og_description) %>">
 
 <% if page_image.present? && page_image.attached? && page_image.variable? %>
-  <% if @product %>
+  <% if @product && !page_image.record.is_a?(Spree::Store) %>
     <% image_url = spree_image_url(page_image, variant: :og_image) %>
   <% else %>
     <% image_url = spree_image_url(page_image, width: 1200, height: 630) %>


### PR DESCRIPTION
When a product has no images, page_image falls back to current_store.social_image. Unlike `Spree::Asset` attachments, social_image has no named variants registered, causing Rails to raise 'Cannot find variant `:og_image` for Spree::Store#social_image'.

Only use variant: :og_image when the image is a product asset, not when it falls back to the store's social_image.

From our Sentry logging:

`Error:
[Sentry] - ActionView::Template::Error: Cannot find variant :og_image for Spree::Store#social_image (ActionView::Template::Error)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Open Graph image meta tag logic to render more accurately and prevent incorrect image display when sharing content socially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->