### PR TITLE
Commit rich text content on blur in page builder editor

### DIFF
--- a/page_builder/app/views/spree/admin/page_blocks/forms/_heading.html.erb
+++ b/page_builder/app/views/spree/admin/page_blocks/forms/_heading.html.erb
@@ -1,6 +1,6 @@
 <div class="trix-container">
   <%= f.rich_text_area :text, data: {
-    action: 'trix-change->auto-submit#submit'
+    action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'
   }, class: 'mb-6' %>
 </div>
 

--- a/page_builder/app/views/spree/admin/page_blocks/forms/_share.html.erb
+++ b/page_builder/app/views/spree/admin/page_blocks/forms/_share.html.erb
@@ -1,5 +1,5 @@
 <div class="trix-container">
   <%= f.rich_text_area :text, data: {
-    action: 'trix-change->auto-submit#submit'
+    action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'
   }, class: 'mb-6' %>
 </div>

--- a/page_builder/app/views/spree/admin/page_blocks/forms/_subheading.html.erb
+++ b/page_builder/app/views/spree/admin/page_blocks/forms/_subheading.html.erb
@@ -1,6 +1,6 @@
 <div class="trix-container">
   <%= f.rich_text_area :text, data: {
-    action: 'trix-change->auto-submit#submit'
+    action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'
   }, class: 'mb-6' %>
 </div>
 

--- a/page_builder/app/views/spree/admin/page_blocks/forms/_text.html.erb
+++ b/page_builder/app/views/spree/admin/page_blocks/forms/_text.html.erb
@@ -1,6 +1,6 @@
 <div class="trix-container">
   <%= f.rich_text_area :text, data: {
-    action: 'trix-change->auto-submit#submit'
+    action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'
   }, class: 'mb-6' %>
 </div>
 

--- a/page_builder/app/views/spree/admin/page_sections/forms/_announcement_bar.html.erb
+++ b/page_builder/app/views/spree/admin/page_sections/forms/_announcement_bar.html.erb
@@ -1,5 +1,5 @@
 <div class="trix-container">
   <%= f.rich_text_area :text, data: {
-    action: 'trix-change->auto-submit#submit'
+    action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'
   }, class: 'mb-4' %>
 </div>

--- a/page_builder/app/views/spree/admin/page_sections/forms/_featured_posts.html.erb
+++ b/page_builder/app/views/spree/admin/page_sections/forms/_featured_posts.html.erb
@@ -13,7 +13,7 @@
 <div class="form-group">
   <%= f.label :description %>
   <div class="trix-container">
-    <%= f.rich_text_area :description, data: {action: 'trix-change->auto-submit#submit'}, class: 'mb-4 w-full' %>
+    <%= f.rich_text_area :description, data: {action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'}, class: 'mb-4 w-full' %>
   </div>
 </div>
 <div class="form-group">

--- a/page_builder/app/views/spree/admin/page_sections/forms/_featured_taxon.html.erb
+++ b/page_builder/app/views/spree/admin/page_sections/forms/_featured_taxon.html.erb
@@ -13,7 +13,7 @@
 <div class="form-group">
   <%= f.label :description %>
   <div class="trix-container">
-    <%= f.rich_text_area :description, data: {action: 'trix-change->auto-submit#submit'}, class: 'mb-4 w-full' %>
+    <%= f.rich_text_area :description, data: {action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'}, class: 'mb-4 w-full' %>
   </div>
 </div>
 <div class="form-group">

--- a/page_builder/app/views/spree/admin/page_sections/forms/_related_products.html.erb
+++ b/page_builder/app/views/spree/admin/page_sections/forms/_related_products.html.erb
@@ -13,7 +13,7 @@
 <div class="form-group">
   <%= f.label :description, Spree.t('admin.page_builder.description') %>
   <div class="trix-container">
-    <%= f.rich_text_area :description, data: {action: 'trix-change->auto-submit#submit'}, class: 'mb-4 w-full' %>
+    <%= f.rich_text_area :description, data: {action: 'trix-change->auto-submit#submit trix-blur->auto-submit#submit'}, class: 'mb-4 w-full' %>
   </div>
 </div>
 <div class="form-group">


### PR DESCRIPTION
Sections/blocks whose only editable field is a rich text area had no way to trigger auto-submit: other field types fall back to a plain field's blur/change event to push the shared form's submit, but a rich-text-only form has no such field, so trix-change alone wasn't reliably propagating edits to the live preview or persisting them. Binding trix-blur alongside trix-change mirrors the blur behavior already used by plain text fields.